### PR TITLE
[NNAdapter][CambriconMLU] dynamic load mm plugins when build from cache

### DIFF
--- a/lite/backends/nnadapter/nnadapter/src/driver/cambricon_mlu/converter/multiclass_nms.cc
+++ b/lite/backends/nnadapter/nnadapter/src/driver/cambricon_mlu/converter/multiclass_nms.cc
@@ -121,9 +121,9 @@ if (converter->get_fusion_yolobox_multiclass_nms3_to_detection_output()){
   converter->UpdateTensorMap(output_nms_rois_num_operand,
                              bias_add_node->GetOutput(0));
 }else{ // not fusion yolobox and multiclass_nms3 to detection_output, use single op instead
-  std::string lib_path = "/usr/local/neuware/lib64/libmulticlass_nms3_plugin.so";
-  auto kernel_lib = dlopen(lib_path.c_str(),RTLD_LAZY);
-  NNADAPTER_CHECK(kernel_lib) << "Failed to dlopen " << lib_path;
+//   std::string lib_path = "/usr/local/neuware/lib64/libmulticlass_nms3_plugin.so";
+//   auto kernel_lib = dlopen(lib_path.c_str(),RTLD_LAZY);
+//   NNADAPTER_CHECK(kernel_lib) << "Failed to dlopen " << lib_path;
 
   const std::string plugin_op_name = "PluginMultiClassNMS3";
   magicmind::TensorMap nms_input_map;

--- a/lite/backends/nnadapter/nnadapter/src/driver/cambricon_mlu/converter/roi_align.cc
+++ b/lite/backends/nnadapter/nnadapter/src/driver/cambricon_mlu/converter/roi_align.cc
@@ -25,9 +25,9 @@ namespace cambricon_mlu {
 int ConvertRoiAlign(Converter* converter, core::Operation* operation) {
   ROI_ALIGN_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
-  std::string lib_path = "/usr/local/neuware/lib64/libmagicmind_plugin.so";
-  auto kernel_lib = dlopen(lib_path.c_str(),RTLD_LAZY);
-  NNADAPTER_CHECK(kernel_lib) << "Failed to dlopen " << lib_path;
+  // std::string lib_path = "/usr/local/neuware/lib64/libmagicmind_plugin.so";
+  // auto kernel_lib = dlopen(lib_path.c_str(),RTLD_LAZY);
+  // NNADAPTER_CHECK(kernel_lib) << "Failed to dlopen " << lib_path;
 
   // Convert to magicmind tensors and node
   auto input_tensor = converter->GetMappedTensor(input_operand);

--- a/lite/backends/nnadapter/nnadapter/src/driver/cambricon_mlu/converter/yolo_box.cc
+++ b/lite/backends/nnadapter/nnadapter/src/driver/cambricon_mlu/converter/yolo_box.cc
@@ -71,9 +71,9 @@ if(converter->get_fusion_yolobox_multiclass_nms3_to_detection_output()){
   converter->UpdateTensorMap(boxes_operand, boxes_tensor);
   converter->UpdateTensorMap(scores_operand, scores_tensor);
 }else{
-  std::string lib_path = "/usr/local/neuware/lib64/libyolo_box_plugin.so";
-  auto kernel_lib = dlopen(lib_path.c_str(),RTLD_LAZY);
-  NNADAPTER_CHECK(kernel_lib) << "Failed to dlopen " << lib_path;
+  // std::string lib_path = "/usr/local/neuware/lib64/libyolo_box_plugin.so";
+  // auto kernel_lib = dlopen(lib_path.c_str(),RTLD_LAZY);
+  // NNADAPTER_CHECK(kernel_lib) << "Failed to dlopen " << lib_path;
   const std::string plugin_op_name = "PluginYoloBox";
   magicmind::TensorMap yolo_box_input_map;
   yolo_box_input_map["Input"] =


### PR DESCRIPTION
![图片](https://user-images.githubusercontent.com/15980746/197108445-4e78adbe-156e-4f19-8fda-b670fc782308.png)
猜测是 build from cache时，3个plugin 都没有动态加载，所以这里将动态加载的逻辑放到engine的build model中；那么不管是否走cache，都会提前动态加载